### PR TITLE
Changed method of obtaining L1 NFT information

### DIFF
--- a/packages/client/src/components/VoteModal.tsx
+++ b/packages/client/src/components/VoteModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import DateTimePicker from './DateTimePicker';
 import { useMUD } from '../MUDContext';
 
@@ -6,7 +6,7 @@ interface VoteModalProps {
   onClose: () => void;
   hackathonId: string;
   submitter: string;
-  setError: (error: string | null) => void; 
+  setError: (error: string | null) => void;
   setSuccess: (success: string | null) => void;
 }
 
@@ -14,6 +14,18 @@ const VoteModal = ({ onClose, hackathonId, submitter, setError, setSuccess}: Vot
   const {
     systemCalls: { vote },
   } = useMUD();
+  
+  const handleVote = async () => {
+    try {
+      await vote(hackathonId, submitter);
+      setSuccess('Your vote has been cast!.');
+    } catch (error) {
+      setError('An error occurred while voting.');
+    }
+    
+    onClose();
+  };
+
   return (
     <div className="p-6">
       <p className="font-bold text-xl flex justify-center">
@@ -22,15 +34,9 @@ const VoteModal = ({ onClose, hackathonId, submitter, setError, setSuccess}: Vot
       <div className="mt-6 flex justify-center">
         <button
           className="btn bg-black text-white rounded-lg w-80"
-          onClick={async (event) => {  
-            event.preventDefault();        
-            try {
-              await vote(hackathonId, submitter);
-              setSuccess('Your vote has been cast!.');
-            } catch (error) {
-              setError('An error occurred while voting.');
-            }
-            onClose();
+          onClick={event => {
+            event.preventDefault();
+            handleVote();
           }}
         >
           Vote

--- a/packages/client/src/mud/contractComponents.ts
+++ b/packages/client/src/mud/contractComponents.ts
@@ -118,7 +118,7 @@ export function defineContractComponents(world: World) {
         world,
         {
           count: RecsType.BigInt,
-          voted: RecsType.Boolean,
+          aggregated: RecsType.Boolean,
         },
         {
           metadata: {

--- a/packages/contracts/mud.config.ts
+++ b/packages/contracts/mud.config.ts
@@ -57,7 +57,7 @@ export default mudConfig({
     Vote: {
       schema: {
         count: "uint256",
-        voted: "bool",
+        aggregated: "bool",
       },
       keySchema: {
         hackathonId: "bytes32",

--- a/packages/contracts/src/codegen/tables/Vote.sol
+++ b/packages/contracts/src/codegen/tables/Vote.sol
@@ -22,7 +22,7 @@ bytes32 constant VoteTableId = _tableId;
 
 struct VoteData {
   uint256 count;
-  bool voted;
+  bool aggregated;
 }
 
 library Vote {
@@ -47,7 +47,7 @@ library Vote {
   function getMetadata() internal pure returns (string memory, string[] memory) {
     string[] memory _fieldNames = new string[](2);
     _fieldNames[0] = "count";
-    _fieldNames[1] = "voted";
+    _fieldNames[1] = "aggregated";
     return ("Vote", _fieldNames);
   }
 
@@ -111,8 +111,8 @@ library Vote {
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((count)));
   }
 
-  /** Get voted */
-  function getVoted(bytes32 hackathonId, address voter) internal view returns (bool voted) {
+  /** Get aggregated */
+  function getAggregated(bytes32 hackathonId, address voter) internal view returns (bool aggregated) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = hackathonId;
     _keyTuple[1] = bytes32(uint256(uint160(voter)));
@@ -121,8 +121,8 @@ library Vote {
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
-  /** Get voted (using the specified store) */
-  function getVoted(IStore _store, bytes32 hackathonId, address voter) internal view returns (bool voted) {
+  /** Get aggregated (using the specified store) */
+  function getAggregated(IStore _store, bytes32 hackathonId, address voter) internal view returns (bool aggregated) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = hackathonId;
     _keyTuple[1] = bytes32(uint256(uint160(voter)));
@@ -131,22 +131,22 @@ library Vote {
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
-  /** Set voted */
-  function setVoted(bytes32 hackathonId, address voter, bool voted) internal {
+  /** Set aggregated */
+  function setAggregated(bytes32 hackathonId, address voter, bool aggregated) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = hackathonId;
     _keyTuple[1] = bytes32(uint256(uint160(voter)));
 
-    StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((voted)));
+    StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((aggregated)));
   }
 
-  /** Set voted (using the specified store) */
-  function setVoted(IStore _store, bytes32 hackathonId, address voter, bool voted) internal {
+  /** Set aggregated (using the specified store) */
+  function setAggregated(IStore _store, bytes32 hackathonId, address voter, bool aggregated) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = hackathonId;
     _keyTuple[1] = bytes32(uint256(uint160(voter)));
 
-    _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((voted)));
+    _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((aggregated)));
   }
 
   /** Get the full data */
@@ -170,8 +170,8 @@ library Vote {
   }
 
   /** Set the full data using individual values */
-  function set(bytes32 hackathonId, address voter, uint256 count, bool voted) internal {
-    bytes memory _data = encode(count, voted);
+  function set(bytes32 hackathonId, address voter, uint256 count, bool aggregated) internal {
+    bytes memory _data = encode(count, aggregated);
 
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = hackathonId;
@@ -181,8 +181,8 @@ library Vote {
   }
 
   /** Set the full data using individual values (using the specified store) */
-  function set(IStore _store, bytes32 hackathonId, address voter, uint256 count, bool voted) internal {
-    bytes memory _data = encode(count, voted);
+  function set(IStore _store, bytes32 hackathonId, address voter, uint256 count, bool aggregated) internal {
+    bytes memory _data = encode(count, aggregated);
 
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = hackathonId;
@@ -193,24 +193,24 @@ library Vote {
 
   /** Set the full data using the data struct */
   function set(bytes32 hackathonId, address voter, VoteData memory _table) internal {
-    set(hackathonId, voter, _table.count, _table.voted);
+    set(hackathonId, voter, _table.count, _table.aggregated);
   }
 
   /** Set the full data using the data struct (using the specified store) */
   function set(IStore _store, bytes32 hackathonId, address voter, VoteData memory _table) internal {
-    set(_store, hackathonId, voter, _table.count, _table.voted);
+    set(_store, hackathonId, voter, _table.count, _table.aggregated);
   }
 
   /** Decode the tightly packed blob using this table's schema */
   function decode(bytes memory _blob) internal pure returns (VoteData memory _table) {
     _table.count = (uint256(Bytes.slice32(_blob, 0)));
 
-    _table.voted = (_toBool(uint8(Bytes.slice1(_blob, 32))));
+    _table.aggregated = (_toBool(uint8(Bytes.slice1(_blob, 32))));
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(uint256 count, bool voted) internal view returns (bytes memory) {
-    return abi.encodePacked(count, voted);
+  function encode(uint256 count, bool aggregated) internal view returns (bytes memory) {
+    return abi.encodePacked(count, aggregated);
   }
 
   /** Encode keys as a bytes32 array using this table's schema */

--- a/packages/contracts/src/codegen/world/ISubmissionSystem.sol
+++ b/packages/contracts/src/codegen/world/ISubmissionSystem.sol
@@ -16,7 +16,5 @@ interface ISubmissionSystem {
 
   function vote(bytes32 _hackathonId, address _submitter) external;
 
-  function continueVote(bytes memory _requestResult, bytes memory _callbackExtraData) external;
-
   function withdrawPrize(bytes32 _hackathonId) external payable;
 }

--- a/packages/contracts/types/ethers-contracts/IWorld.ts
+++ b/packages/contracts/types/ethers-contracts/IWorld.ts
@@ -105,18 +105,17 @@ export type SubmissionDataStructOutput = [
 
 export type VoteDataStruct = {
   count: PromiseOrValue<BigNumberish>;
-  voted: PromiseOrValue<boolean>;
+  aggregated: PromiseOrValue<boolean>;
 };
 
 export type VoteDataStructOutput = [BigNumber, boolean] & {
   count: BigNumber;
-  voted: boolean;
+  aggregated: boolean;
 };
 
 export interface IWorldInterface extends utils.Interface {
   functions: {
     "call(bytes16,bytes16,bytes)": FunctionFragment;
-    "continueVote(bytes,bytes)": FunctionFragment;
     "createHackathon(address,uint256,uint256,uint256,uint256,uint8,string,string,string,address,uint64)": FunctionFragment;
     "deleteHackathon(bytes32)": FunctionFragment;
     "deleteRecord(bytes32,bytes32[])": FunctionFragment;
@@ -177,7 +176,6 @@ export interface IWorldInterface extends utils.Interface {
   getFunction(
     nameOrSignatureOrTopic:
       | "call"
-      | "continueVote"
       | "createHackathon"
       | "deleteHackathon"
       | "deleteRecord(bytes32,bytes32[])"
@@ -242,10 +240,6 @@ export interface IWorldInterface extends utils.Interface {
       PromiseOrValue<BytesLike>,
       PromiseOrValue<BytesLike>
     ]
-  ): string;
-  encodeFunctionData(
-    functionFragment: "continueVote",
-    values: [PromiseOrValue<BytesLike>, PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
     functionFragment: "createHackathon",
@@ -636,10 +630,6 @@ export interface IWorldInterface extends utils.Interface {
 
   decodeFunctionResult(functionFragment: "call", data: BytesLike): Result;
   decodeFunctionResult(
-    functionFragment: "continueVote",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
     functionFragment: "createHackathon",
     data: BytesLike
   ): Result;
@@ -941,12 +931,6 @@ export interface IWorld extends BaseContract {
       name: PromiseOrValue<BytesLike>,
       funcSelectorAndArgs: PromiseOrValue<BytesLike>,
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
-    ): Promise<ContractTransaction>;
-
-    continueVote(
-      _requestResult: PromiseOrValue<BytesLike>,
-      _callbackExtraData: PromiseOrValue<BytesLike>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
     createHackathon(
@@ -1343,12 +1327,6 @@ export interface IWorld extends BaseContract {
     overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
-  continueVote(
-    _requestResult: PromiseOrValue<BytesLike>,
-    _callbackExtraData: PromiseOrValue<BytesLike>,
-    overrides?: Overrides & { from?: PromiseOrValue<string> }
-  ): Promise<ContractTransaction>;
-
   createHackathon(
     _prizeToken: PromiseOrValue<string>,
     _startTimestamp: PromiseOrValue<BigNumberish>,
@@ -1742,12 +1720,6 @@ export interface IWorld extends BaseContract {
       funcSelectorAndArgs: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<string>;
-
-    continueVote(
-      _requestResult: PromiseOrValue<BytesLike>,
-      _callbackExtraData: PromiseOrValue<BytesLike>,
-      overrides?: CallOverrides
-    ): Promise<void>;
 
     createHackathon(
       _prizeToken: PromiseOrValue<string>,
@@ -2188,12 +2160,6 @@ export interface IWorld extends BaseContract {
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
-    continueVote(
-      _requestResult: PromiseOrValue<BytesLike>,
-      _callbackExtraData: PromiseOrValue<BytesLike>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
-    ): Promise<BigNumber>;
-
     createHackathon(
       _prizeToken: PromiseOrValue<string>,
       _startTimestamp: PromiseOrValue<BigNumberish>,
@@ -2587,12 +2553,6 @@ export interface IWorld extends BaseContract {
       name: PromiseOrValue<BytesLike>,
       funcSelectorAndArgs: PromiseOrValue<BytesLike>,
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
-    ): Promise<PopulatedTransaction>;
-
-    continueVote(
-      _requestResult: PromiseOrValue<BytesLike>,
-      _callbackExtraData: PromiseOrValue<BytesLike>,
-      overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
     createHackathon(

--- a/packages/contracts/types/ethers-contracts/factories/IWorld__factory.ts
+++ b/packages/contracts/types/ethers-contracts/factories/IWorld__factory.ts
@@ -328,24 +328,6 @@ const _abi = [
   {
     inputs: [
       {
-        internalType: "bytes",
-        name: "_requestResult",
-        type: "bytes",
-      },
-      {
-        internalType: "bytes",
-        name: "_callbackExtraData",
-        type: "bytes",
-      },
-    ],
-    name: "continueVote",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      {
         internalType: "address",
         name: "_prizeToken",
         type: "address",
@@ -945,7 +927,7 @@ const _abi = [
           },
           {
             internalType: "bool",
-            name: "voted",
+            name: "aggregated",
             type: "bool",
           },
         ],

--- a/packages/contracts/worlds.json
+++ b/packages/contracts/worlds.json
@@ -1,7 +1,7 @@
 {
   "420": {
-    "address": "0x041a8e17041007598B1a8B0AB608711be3e75036",
-    "blockNumber": 13898174
+    "address": "0xEBe7F90b52C3633aEeD3eFD731537159C3cC47B2",
+    "blockNumber": 14034872
   },
   "4242": {
     "address": "0x5f561e453Fd8776870bD4776B5406309f996F578",


### PR DESCRIPTION
# What

Determine the number of L1 acquisitions with the following contract outside the MUD
https://github.com/aw-labs/erc721L1BalanceOnL2

Corrected the contract in Vote in the MUD based on the above changes.

# Why

Because MUD's signing prevented us from writing code that would refer to it within the MUD, we could not write code that would refer to it.